### PR TITLE
Script Merger Unofficial Patch Load Order fix

### DIFF
--- a/WitcherScriptMerger/LoadOrder/CustomLoadOrder.cs
+++ b/WitcherScriptMerger/LoadOrder/CustomLoadOrder.cs
@@ -167,8 +167,8 @@ namespace WitcherScriptMerger.LoadOrder
             {
                 builder
                     .Append("[").Append(modSetting.ModName).AppendLine("]")
-                    .Append("Enabled = ").AppendLine(Convert.ToInt32(modSetting.IsEnabled).ToString())
-                    .Append("Priority = ").AppendLine(modSetting.Priority.ToString());
+                    .Append("Enabled=").AppendLine(Convert.ToInt32(modSetting.IsEnabled).ToString())
+                    .Append("Priority=").AppendLine(modSetting.Priority.ToString());
 
                 if (modSetting != Mods.Last())
                     builder.AppendLine();

--- a/WitcherScriptMerger/Properties/AssemblyInfo.cs
+++ b/WitcherScriptMerger/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.2.2")]
-[assembly: AssemblyFileVersion("0.6.2")]
+[assembly: AssemblyVersion("0.6.2.3")]
+[assembly: AssemblyFileVersion("0.6.2.3")]


### PR DESCRIPTION
Fix for a bug where Load order priorities set through the Script Merger with the SM unofficial patch 2 were being ignored by the game.